### PR TITLE
Small Fix

### DIFF
--- a/src/v2/guide/components-registration.md
+++ b/src/v2/guide/components-registration.md
@@ -50,7 +50,7 @@ Vue.component('my-component-name', {
 })
 ```
 
-Este componentes são **registrados globalmente**. Isso significa que eles podem ser usados em _templates_ de qualquer instância Vue (`new Vue`) criada após o registro. Por exemplo:
+Estes componentes são **registrados globalmente**. Isso significa que eles podem ser usados em _templates_ de qualquer instância Vue (`new Vue`) criada após o registro. Por exemplo:
 
 ```js
 Vue.component('component-a', { /* ... */ })


### PR DESCRIPTION
'These components' should be translated into 'Estes componentes', not 'Este componentes'.

Accepted formats:
'Estes componentes' => 'These components'.
'Este componente' => 'This component'.