### PR TITLE
docs: update Scrimba link according to original docs

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -39,7 +39,7 @@ ou:
 
 No tópico [Instalação](installation.html) se encontram mais opções para instalar o Vue. Nota: **não recomendamos** a iniciantes começar com `vue-cli`, especialmente se você ainda não está familiarizado com ferramentas de _build_ baseadas em Node.js.
 
-Se você preferir algo mais interativo, pode dar uma olhada [nesta série de tutoriais no Scrimba](https://scrimba.com/playlist/pXKqta), onde você encontra um misto de _screencast_ e _playground_ de código que pode pausar e executar como quiser.
+Se você preferir algo mais interativo, pode dar uma olhada [nesta série de tutoriais no Scrimba](https://scrimba.com/g/gvuedocs), onde você encontra um misto de _screencast_ e _playground_ de código que pode pausar e executar como quiser.
 
 ## Renderização Declarativa
 


### PR DESCRIPTION
The link to the Scrimba tutorial has changed. Evan You merged in the updated link to the original Vue docs earlier today, so I created this PR so that the Russian translation can stay up to date.

Here's the original PR: vuejs/vuejs.org#2368